### PR TITLE
Bump pangeo/base-image from 2020.09.13 to 2020.10.16 in /binder (#19)

### DIFF
--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -1,1 +1,1 @@
-FROM pangeo/base-image:2020.09.13
+FROM pangeo/base-image:2020.10.16


### PR DESCRIPTION
Bumps pangeo/base-image from 2020.09.13 to 2020.10.16.

Signed-off-by: dependabot[bot] <support@github.com>

Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>